### PR TITLE
Improving extensions usage

### DIFF
--- a/GUI/extensions.h
+++ b/GUI/extensions.h
@@ -16,7 +16,7 @@ struct InfoForExtension
 	int propertyValue;
 	InfoForExtension* nextProperty;
 };
-typedef wchar_t*(*ExtensionFunction)(wchar_t*, InfoForExtension*);
+typedef const wchar_t*(*ExtensionFunction)(const wchar_t*, InfoForExtension*);
 extern QComboBox* ttCombo;
 
 #endif // EXTENSIONS_H


### PR DESCRIPTION
I have small suggestion:
1. Use mutex instead of sleep in loop
2. Avoid copying original sentence.
3. Free memory if user returns new one.
4. Do not let user modify existing string and instead let him create new one(or maybe it is better for it to not be const? but then user could free himself memory)